### PR TITLE
Added environment variable to specifiy .fornodesrc file

### DIFF
--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -27,11 +27,14 @@ sub clear_universe () {
 }
 
 sub init_rc () {
-    my $home = $ENV{SSH_BATCH_HOME} || File::HomeDir->my_home;
-    if (!defined $home || !-d $home) {
-        die "Can't find the home for the current user.\n";
-    }
-    my $rcfile = "$home/.fornodesrc";
+	my $rcfile = $ENV{SSH_BATCH_RC} || q();
+	if(! $rcfile){
+	    my $home = $ENV{SSH_BATCH_HOME} || File::HomeDir->my_home;
+	    if (!defined $home || !-d $home) {
+	        die "Can't find the home for the current user.\n";
+	    }
+	    $rcfile = "$home/.fornodesrc";
+	}
 
     # auto create $rcfile if $rcfile not exists
     if (! -e $rcfile) {


### PR DESCRIPTION
In our environment, _fornodes_ and _atnodes_ is run from various hosts and it becomes a pain to keep these files in sync. Providing a central (versioned) file that is accessible on all servers is a big plus.
