### PR TITLE
Added include capability

### DIFF
--- a/bin/key2nodes
+++ b/bin/key2nodes
@@ -23,6 +23,7 @@ my (@exprs);
 my $concurrency = 20;
 my $fetch_value;
 my $ssh_cmd = $ENV{SSH_BATCH_SSH_CMD};
+my $pubkey_file = "";
 for (@ARGV) {
     if (defined $fetch_value) {
         $fetch_value->($_);
@@ -50,6 +51,8 @@ for (@ARGV) {
             $fetch_value = sub { $ssh_cmd = shift };
         } elsif ($group eq 'c') {
             $fetch_value = sub { $concurrency = shift };
+        } elsif ($group eq 'k') {
+            $fetch_value = sub { $pubkey_file = shift };
         } else {
             die "Unknown option: $_\n";
         }
@@ -72,12 +75,17 @@ if (!defined $home) {
     die "Can't find the home for the current user.\n";
 }
 
-my $pubkey_file = "$home/.ssh/id_rsa.pub";
+my $genkey = 0;
+if ($pubkey_file eq ""){
+    $pubkey_file = "$home/.ssh/id_rsa.pub";
+    $genkey = 1;
+}
+
 if (-f $pubkey_file) {
     if ($verbose) {
         warn "Found public key file $pubkey_file.\n";
     }
-} else {
+} elsif ($genkey == 1){
     my $cmd = "(echo; echo y; echo; echo) | ssh-keygen -q -t rsa";
     if ($verbose) {
         warn "Running command [$cmd]...\n";
@@ -85,6 +93,9 @@ if (-f $pubkey_file) {
     if (system($cmd) != 0) {
         die "Generating SSH key failed.\n";
     }
+}
+else{
+    die "Public key file $pubkey_file not found.";
 }
 
 open my $in, $pubkey_file or
@@ -236,6 +247,7 @@ OPTIONS:
     -c <num>      Set SSH concurrency limit. (default: 20)
     -h            Print this help.
     -l            List the hosts and do nothing else.
+    -k            SSH Public Key to upload.
     -p <port>     Port for the remote SSH service.
     -ssh <path>   Specify an alternate ssh program.
                   (This overrides the SSH_BATCH_SSH_CMD environment.)
@@ -279,6 +291,7 @@ key2nodes - Push SSH public keys to remote clusters
     -c <num>      Set SSH concurrency limit. (default: 20)
     -h            Print this help.
     -l            List the hosts and do nothing else.
+    -k            SSH Public Key to upload.
     -p <port>     Port for the remote SSH service.
     -ssh <path>   Specify an alternate ssh program.
                   (This overrides the SSH_BATCH_SSH_CMD environment.)

--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -55,13 +55,10 @@ sub init_rc () {
 sub load_rc ($$) {
     my ($rc, $rcfile) = @_;
     my $accum_ln;
-
-    while (<$rc>) {
-    	
+    while (<$rc>) {   	
         s/\#.*//;
         next if /^\s*$/;
         chomp;
-        
         if (s/\\\s*$//s) {
             $accum_ln .= " $_";
             next;
@@ -71,7 +68,6 @@ sub load_rc ($$) {
             undef $accum_ln;
             next;
         }
-        
         parse_line($_, $rcfile);
     }
 }

--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -71,24 +71,6 @@ sub load_rc ($$) {
             undef $accum_ln;
             next;
         }
-        if (/^include\s*=\s*"?(~?\/?([\w\.-]+\/)*[\w\.-]+)"?\s*$/i){
-        	my $includefile = $1;
-        	if($includefile =~ /^~(.*)$/){
-        		$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . $1;        		
-        	}
-        	
-        	if(! -e $includefile){
-        		die "Include file $includefile does not exist!\n";
-        	}
-		    open my $rcsub, $includefile or
-		        die "Can't open $includefile for reading: $!\n";
-		        
-		    load_rc($rcsub, $includefile);
-		    
-		    close $rcsub;
-		    
-        	next;
-        }
         
         parse_line($_, $rcfile);
     }
@@ -102,6 +84,26 @@ sub parse_line ($$) {
         if ($var !~ /^\w[-\.\w]*$/) {
             die "Invalid variable name in $rcfile, line $.: ",
                 "$var\n";
+        }
+        if ($var =~ /include/i){
+        	if($def =~ /\s*"?(~?\/?([\w\.-]+\/)*[\w\.-]+)"?\s*$/){
+	        	my $includefile = $1;
+	        	if($includefile =~ /^~(.*)$/){
+	        		$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . $1;        		
+	        	}
+	        	
+	        	if(! -e $includefile){
+	        		die "Include file $includefile does not exist!\n";
+	        	}
+			    open my $rcsub, $includefile or
+			        die "Can't open $includefile for reading: $!\n";
+			        
+			    load_rc($rcsub, $includefile);
+			    
+			    close $rcsub;
+        		
+        	}
+        	return;
         }
         my $set;
         eval {

--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -85,26 +85,6 @@ sub parse_line ($$) {
             die "Invalid variable name in $rcfile, line $.: ",
                 "$var\n";
         }
-        if ($var =~ /include/i){
-        	if($def =~ /\s*"?(~?\/?([\w\.-]+\/)*[\w\.-]+)"?\s*$/){
-	        	my $includefile = $1;
-	        	if($includefile =~ /^~(.*)$/){
-	        		$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . $1;        		
-	        	}
-	        	
-	        	if(! -e $includefile){
-	        		die "Include file $includefile does not exist!\n";
-	        	}
-			    open my $rcsub, $includefile or
-			        die "Can't open $includefile for reading: $!\n";
-			        
-			    load_rc($rcsub, $includefile);
-			    
-			    close $rcsub;
-        		
-        	}
-        	return;
-        }
         my $set;
         eval {
             $set = parse_expr($def);
@@ -118,7 +98,29 @@ sub parse_line ($$) {
             }
             $Vars{$var} = $set;
         }
-    } else {
+    }
+    elsif(/^\s*include\s*:\s*(.*)/i){
+        if($1 =~ /\s*"?(~?\/?([\w\.-]+\/)*[\w\.-]+)"?\s*$/){
+	        my $includefile = $1;
+	        if($includefile =~ /^~(.*)$/){
+	        	$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . $1;        		
+	        }
+	        	
+	        if(! -e $includefile){
+	        	die "Include file $includefile does not exist!\n";
+	        }
+			open my $rcsub, $includefile or
+			    die "Can't open $includefile for reading: $!\n";
+			        
+			load_rc($rcsub, $includefile);
+			    
+			close $rcsub;
+        		
+        }
+        return;
+    	
+    }
+    else {
         die "Syntax error in $rcfile, line $.: $_\n";
     }
 }

--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -55,7 +55,7 @@ sub init_rc () {
 sub load_rc ($$) {
     my ($rc, $rcfile) = @_;
     my $accum_ln;
-    while (<$rc>) {   	
+    while (<$rc>) {
         s/\#.*//;
         next if /^\s*$/;
         chomp;

--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -55,10 +55,13 @@ sub init_rc () {
 sub load_rc ($$) {
     my ($rc, $rcfile) = @_;
     my $accum_ln;
+
     while (<$rc>) {
+    	
         s/\#.*//;
         next if /^\s*$/;
         chomp;
+        
         if (s/\\\s*$//s) {
             $accum_ln .= " $_";
             next;
@@ -68,6 +71,25 @@ sub load_rc ($$) {
             undef $accum_ln;
             next;
         }
+        if (/^include\s*=\s*"?(~?\/?([\w\.-]+\/)*[\w\.-]+)"?\s*$/i){
+        	my $includefile = $1;
+        	if($includefile =~ /^~(.*)$/){
+        		$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . $1;        		
+        	}
+        	
+        	if(! -e $includefile){
+        		die "Include file $includefile does not exist!\n";
+        	}
+		    open my $rcsub, $includefile or
+		        die "Can't open $includefile for reading: $!\n";
+		        
+		    load_rc($rcsub, $includefile);
+		    
+		    close $rcsub;
+		    
+        	next;
+        }
+        
         parse_line($_, $rcfile);
     }
 }

--- a/lib/SSH/Batch/ForNodes.pm
+++ b/lib/SSH/Batch/ForNodes.pm
@@ -99,24 +99,22 @@ sub parse_line ($$) {
             $Vars{$var} = $set;
         }
     }
-    elsif(/^\s*include\s*:\s*(.*)/i){
-        if($1 =~ /\s*"?(~?\/?([\w\.-]+\/)*[\w\.-]+)"?\s*$/){
-	        my $includefile = $1;
-	        if($includefile =~ /^~(.*)$/){
-	        	$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . $1;        		
-	        }
-	        	
-	        if(! -e $includefile){
-	        	die "Include file $includefile does not exist!\n";
-	        }
-			open my $rcsub, $includefile or
-			    die "Can't open $includefile for reading: $!\n";
-			        
-			load_rc($rcsub, $includefile);
-			    
-			close $rcsub;
-        		
+    elsif(/^\s*include\s*:\s*"?([^"]*)"?\s*$/i){
+        my $includefile = $1;
+        if($includefile =~ /^~\/(.*)$/){
+        	$includefile = ($ENV{SSH_BATCH_HOME} ||  File::HomeDir->my_home) . '/' .  $1;
         }
+        	
+        if(! -e $includefile){
+        	die "Include file $includefile does not exist!\n";
+        }
+		open my $rcsub, $includefile or
+		    die "Can't open $includefile for reading: $!\n";
+		        
+		load_rc($rcsub, $includefile);
+		    
+		close $rcsub;
+        		
         return;
     	
     }


### PR DESCRIPTION
Added ability to include files from .fornodesrc
Useful for cases where the .fornodesrc file is very large, or a central common file is needed to be appended.

syntax:
_include: path/file.name_
May be quoted.

Will process the include inline, where found.